### PR TITLE
Add GetMissionControlConfig, QueryMissionControl and ListAddresses

### DIFF
--- a/lndgrpc/router.py
+++ b/lndgrpc/router.py
@@ -76,3 +76,21 @@ class RouterRPC(BaseClient):
         )
         response = self._router_stub.UpdateChanStatus(request)
         return response
+    
+    @handle_rpc_errors
+    def get_mission_control_config(self):
+        """
+        GetMissionControlConfig
+        """
+        request = router.GetMissionControlConfigRequest()
+        response = self._router_stub.GetMissionControlConfig(request)
+        return response
+    
+    @handle_rpc_errors
+    def query_mission_control(self):
+        """
+        QueryMissionControl
+        """
+        request = router.QueryMissionControlRequest()
+        response = self._router_stub.QueryMissionControl(request)
+        return response

--- a/lndgrpc/walletkit.py
+++ b/lndgrpc/walletkit.py
@@ -44,6 +44,15 @@ class WalletRPC(BaseClient):
         request = walletkit.ListAccountsRequest(**kwargs)
         response = self._walletkit_stub.ListAccounts(request)
         return response
+    
+    @handle_rpc_errors
+    def list_addresses(self, **kwargs):
+        """
+        ListAddresses
+        """
+        request = walletkit.ListAddressesRequest(**kwargs)
+        response = self._walletkit_stub.ListAddresses(request)
+        return response
 
     @handle_rpc_errors
     def list_unspent(self, min_confs=0,max_confs=100000, **kwargs):


### PR DESCRIPTION
Found some calls which are not included yet. This PR:

1) Enables GetMissionControlConfig, QueryMissionControl for routerrpc 
2) Enables ListAddresses for walletkit